### PR TITLE
Hey I added 3 new PS3MAPI OPCODES

### DIFF
--- a/484/DEX/lv2/include/lv2/memory.h
+++ b/484/DEX/lv2/include/lv2/memory.h
@@ -21,6 +21,8 @@ LV2_EXPORT int copy_to_user(void *src, void *user_dst, int size);
 LV2_EXPORT int copy_from_user(void *user_src, void *dst, int size);
 LV2_EXPORT int copy_to_process(process_t process, void *src, void *foreign_dst, int size);
 LV2_EXPORT int copy_from_process(process_t process, void *foreign_src, void *dst, int size);
+LV2_EXPORT int process_read_memory(process_t process, void *destination, void *source, size_t size);
+LV2_EXPORT int process_write_memory(process_t process, void *destination, void *source, size_t size, int flag);
 
 LV2_EXPORT int kernel_ea_to_lpar_addr(void *ea_addr, uint64_t *lpar_addr);
 LV2_EXPORT int process_ea_to_lpar_addr_ex(void *mem_object, void *ea_addr, uint64_t *lpar_addr);

--- a/484/DEX/lv2/include/lv2/symbols.h
+++ b/484/DEX/lv2/include/lv2/symbols.h
@@ -20,6 +20,8 @@
 #define copy_from_user_symbol							0xFA88
 #define copy_to_process_symbol							0xF924
 #define copy_from_process_symbol						0xF734
+#define process_read_memory_symbol                        0x267EC0
+#define process_write_memory_symbol                       0x267D34
 #define page_allocate_symbol							0x60394
 #define page_free_symbol								0x5FDF8
 #define page_export_to_proc_symbol						0x60530
@@ -268,6 +270,8 @@
 #define copy_from_user_symbol							0x100D0
 #define copy_to_process_symbol							0xFF6C
 #define copy_from_process_symbol						0xFD7C
+#define process_read_memory_symbol						0x26E7E4
+#define process_write_memory_symbol						0x26E658
 #define page_allocate_symbol							0x63D64
 #define page_free_symbol								0x637C8
 #define page_export_to_proc_symbol						0x63F00

--- a/484/DEX/lv2/src/memory.S
+++ b/484/DEX/lv2/src/memory.S
@@ -20,3 +20,5 @@ LV2_FUNCTION(process_ea_to_lpar_addr_ex, process_ea_to_lpar_addr_ex_symbol)
 LV2_FUNCTION(set_pte, set_pte_symbol)
 
 
+LV2_FUNCTION(process_read_memory, process_read_memory_symbol)
+LV2_FUNCTION(process_write_memory, process_write_memory_symbol)

--- a/484/DEX/stage2/main.c
+++ b/484/DEX/stage2/main.c
@@ -693,6 +693,9 @@ LV2_SYSCALL2(int64_t, syscall8, (uint64_t function, uint64_t param1, uint64_t pa
 				case PS3MAPI_OPCODE_SET_PROC_MEM:
 					return ps3mapi_set_process_mem((process_id_t)param2, param3, (char *)param4, (int)param5);
 				break;
+				case PS3MAPI_OPCODE_PROC_PAGE_ALLOCATE:
+					return ps3mapi_process_page_allocate((process_id_t)param2, param3, param4, param5, (uint32_t *)param6);
+				break;
 
 				//----------
 				//MODULE
@@ -711,6 +714,9 @@ LV2_SYSCALL2(int64_t, syscall8, (uint64_t function, uint64_t param1, uint64_t pa
 				break;
 				case PS3MAPI_OPCODE_UNLOAD_PROC_MODULE:
 					return ps3mapi_unload_process_modules((process_id_t)param2, (sys_prx_id_t)param3);
+				break;
+				case PS3MAPI_OPCODE_GET_PROC_MODULE_INFO:
+					return ps3mapi_get_process_module_info((process_id_t)param2, (sys_prx_id_t)param3, (sys_prx_module_info_t *)param4);
 				break;
 
 				//----------
@@ -852,6 +858,10 @@ LV2_SYSCALL2(int64_t, syscall8, (uint64_t function, uint64_t param1, uint64_t pa
 			return unload_plugin_kernel(param1);
 		break;
 
+		case SYSCALL8_OPCODE_PROC_CREATE_THREAD:
+			return ps3mapi_create_process_thread((process_id_t)param1, (thread_t *)param2, (void *)param3, (uint64_t)param4, (int)param5, (size_t)param6, (const char *)param7);
+		break;
+			
 		case SYSCALL8_OPCODE_MOUNT_PSX_DISCFILE:
 			return sys_storage_ext_mount_psx_discfile((char *)param1, param2, (ScsiTrackDescriptor *)param3);
 		break;

--- a/484/DEX/stage2/ps3mapi_core.h
+++ b/484/DEX/stage2/ps3mapi_core.h
@@ -76,9 +76,11 @@ int ps3mapi_get_current_process(process_t process);
 
 #define PS3MAPI_OPCODE_GET_PROC_MEM				0x0031
 #define PS3MAPI_OPCODE_SET_PROC_MEM				0x0032
+#define PS3MAPI_OPCODE_PROC_PAGE_ALLOCATE			0x0033
 
 int ps3mapi_set_process_mem(process_id_t pid, uint64_t addr, char *buf, int size);
 int ps3mapi_get_process_mem(process_id_t pid, uint64_t addr, char *buf, int size);
+int ps3mapi_process_page_allocate(process_id_t pid, uint64_t size, uint64_t page_size, uint64_t flags, uint32_t *start_address);
 
 //-----------------------------------------------
 //MODULES
@@ -91,12 +93,22 @@ int ps3mapi_get_process_mem(process_id_t pid, uint64_t addr, char *buf, int size
 #define PS3MAPI_OPCODE_UNLOAD_PROC_MODULE			0x0045
 #define PS3MAPI_OPCODE_UNLOAD_VSH_PLUGIN			0x0046 //Look in modulespatch.c for code.
 #define PS3MAPI_OPCODE_GET_VSH_PLUGIN_INFO			0x0047 //Look in modulespatch.c for code.
+#define PS3MAPI_OPCODE_GET_PROC_MODULE_INFO			0x0048
 
 int ps3mapi_get_all_process_modules_prx_id(process_id_t pid, sys_prx_id_t *prx_id_list);
 int ps3mapi_get_process_module_name_by_prx_id(process_id_t pid, sys_prx_id_t prx_id, char *name);
 int ps3mapi_get_process_module_filename_by_prx_id(process_id_t pid, sys_prx_id_t prx_id, char *name);
 int ps3mapi_load_process_modules(process_id_t pid, char *path, void *arg, uint32_t arg_size);
 int ps3mapi_unload_process_modules(process_id_t pid, sys_prx_id_t prx_id);
+int ps3mapi_get_process_module_info(process_id_t pid, sys_prx_id_t prx_id, sys_prx_module_info_t *info);
+
+//-----------------------------------------------
+//THREAD
+//-----------------------------------------------
+
+#define SYSCALL8_OPCODE_PROC_CREATE_THREAD			0x6E03 // not eough params for PS3MAPI_OPCODE
+
+int ps3mapi_create_process_thread(process_id_t pid, thread_t *thread, void *entry, uint64_t arg, int prio, size_t stacksize, const char *threadname);
 
 //-----------------------------------------------
 //SYSCALL

--- a/484/LITE/SRC/lv2/include/lv2/memory.h
+++ b/484/LITE/SRC/lv2/include/lv2/memory.h
@@ -21,6 +21,8 @@ LV2_EXPORT int copy_to_user(void *src, void *user_dst, int size);
 LV2_EXPORT int copy_from_user(void *user_src, void *dst, int size);
 LV2_EXPORT int copy_to_process(process_t process, void *src, void *foreign_dst, int size);
 LV2_EXPORT int copy_from_process(process_t process, void *foreign_src, void *dst, int size);
+LV2_EXPORT int process_read_memory(process_t process, void *destination, void *source, size_t size);
+LV2_EXPORT int process_write_memory(process_t process, void *destination, void *source, size_t size, int flag);
 
 LV2_EXPORT int kernel_ea_to_lpar_addr(void *ea_addr, uint64_t *lpar_addr);
 LV2_EXPORT int process_ea_to_lpar_addr_ex(void *mem_object, void *ea_addr, uint64_t *lpar_addr);

--- a/484/LITE/SRC/lv2/include/lv2/symbols.h
+++ b/484/LITE/SRC/lv2/include/lv2/symbols.h
@@ -20,6 +20,8 @@
 #define copy_from_user_symbol							0xFA88
 #define copy_to_process_symbol							0xF924
 #define copy_from_process_symbol						0xF734
+#define process_read_memory_symbol                        0x267EC0
+#define process_write_memory_symbol                       0x267D34
 #define page_allocate_symbol							0x60394
 #define page_free_symbol								0x5FDF8
 #define page_export_to_proc_symbol						0x60530

--- a/484/LITE/SRC/lv2/src/memory.S
+++ b/484/LITE/SRC/lv2/src/memory.S
@@ -20,3 +20,5 @@ LV2_FUNCTION(process_ea_to_lpar_addr_ex, process_ea_to_lpar_addr_ex_symbol)
 LV2_FUNCTION(set_pte, set_pte_symbol)
 
 
+LV2_FUNCTION(process_read_memory, process_read_memory_symbol)
+LV2_FUNCTION(process_write_memory, process_write_memory_symbol)

--- a/484/LITE/SRC/stage2/main.c
+++ b/484/LITE/SRC/stage2/main.c
@@ -656,6 +656,9 @@ LV2_SYSCALL2(int64_t, syscall8, (uint64_t function, uint64_t param1, uint64_t pa
 				case PS3MAPI_OPCODE_SET_PROC_MEM:
 					return ps3mapi_set_process_mem((process_id_t)param2, param3, (char *)param4, (int)param5);
 				break;
+				case PS3MAPI_OPCODE_PROC_PAGE_ALLOCATE:
+					return ps3mapi_process_page_allocate((process_id_t)param2, param3, param4, param5, (uint32_t *)param6);
+				break;
 				//----------
 				//MODULE
 				//----------
@@ -673,6 +676,9 @@ LV2_SYSCALL2(int64_t, syscall8, (uint64_t function, uint64_t param1, uint64_t pa
 				break;
 				case PS3MAPI_OPCODE_UNLOAD_PROC_MODULE:
 					return ps3mapi_unload_process_modules((process_id_t)param2, (sys_prx_id_t)param3);
+				break;
+				case PS3MAPI_OPCODE_GET_PROC_MODULE_INFO:
+					return ps3mapi_get_process_module_info((process_id_t)param2, (sys_prx_id_t)param3, (sys_prx_module_info_t *)param4);
 				break;
 				//----------
 				//VSH PLUGINS
@@ -808,6 +814,10 @@ LV2_SYSCALL2(int64_t, syscall8, (uint64_t function, uint64_t param1, uint64_t pa
 		case SYSCALL8_OPCODE_UNLOAD_PAYLOAD_DYNAMIC:
 			return unload_plugin_kernel(param1);
 		break;
+			
+		case SYSCALL8_OPCODE_PROC_CREATE_THREAD:
+			return ps3mapi_create_process_thread((process_id_t)param1, (thread_t *)param2, (void *)param3, (uint64_t)param4, (int)param5, (size_t)param6, (const char *)param7);
+		break;	
 
 		case SYSCALL8_OPCODE_MOUNT_PSX_DISCFILE:
 			return sys_storage_ext_mount_psx_discfile((char *)param1, param2, (ScsiTrackDescriptor *)param3);

--- a/484/LITE/SRC/stage2/ps3mapi_core.c
+++ b/484/LITE/SRC/stage2/ps3mapi_core.c
@@ -151,7 +151,7 @@ int ps3mapi_set_process_mem(process_id_t pid, uint64_t addr, char *buf, int size
 	if (process <= 0)
 		return ESRCH;
 	else 
-		return copy_to_process(process, (void *)get_secure_user_ptr(buf), (void *)addr, size);
+		return process_write_memory(process, (void *)addr, (void *)get_secure_user_ptr(buf), size, 1);
 }
 
 int ps3mapi_get_process_mem(process_id_t pid, uint64_t addr, char *buf, int size)
@@ -173,6 +173,38 @@ int ps3mapi_get_process_mem(process_id_t pid, uint64_t addr, char *buf, int size
 
 	ret = copy_to_user(buff, (void *)get_secure_user_ptr(buf), size);
 	dealloc(buff, 0x27);
+	return ret;
+}
+
+int ps3mapi_process_page_allocate(process_id_t pid, uint64_t size, uint64_t page_size, uint64_t flags, uint32_t *start_address)
+{
+	process_t process = ps3mapi_internal_get_process_by_pid(pid);
+
+	if (process <= 0)
+		return ESRCH;
+
+	int ret;
+	uint8_t *kbuf, *vbuf;
+	ret = page_allocate(process, size, flags, page_size, (void **)&kbuf);
+	if (ret != SUCCEEDED)
+	{
+		return ret;
+	}
+
+	ret = page_export_to_proc(process, kbuf, 0x40000, (void **)&vbuf);
+	if (ret != SUCCEEDED)
+	{
+		return ret;
+	}
+
+	uint32_t page_address = (uint32_t)vbuf;
+	ret = copy_to_user(&page_address, get_secure_user_ptr(start_address), sizeof(uint32_t));
+
+	if (vbuf)
+	{
+		page_free(process, kbuf, flags);
+	}
+
 	return ret;
 }
 
@@ -352,6 +384,78 @@ int ps3mapi_unload_process_modules(process_id_t pid, sys_prx_id_t prx_id)
 
 	if (ret == SUCCEEDED) 
 		ret = prx_unload_module(prx_id, process);
+
+	return ret;
+}
+
+int ps3mapi_get_process_module_info(process_id_t pid, sys_prx_id_t prx_id, sys_prx_module_info_t *info)
+{
+	process_t process = ps3mapi_internal_get_process_by_pid(pid);
+
+	if (process <= 0)
+		return ESRCH;
+
+	char *filename = alloc(512, 0x35);
+
+	if (!filename)
+		return ENOMEM;
+
+	sys_prx_segment_info_t *segments = alloc(10 * sizeof(sys_prx_segment_info_t), 0x35);
+
+	if (!segments)
+	{
+		dealloc(filename, 0x35);
+		return ENOMEM;
+	}
+
+	sys_prx_module_info_t modinfo;
+	memset(&modinfo, 0, sizeof(sys_prx_module_info_t));
+
+	modinfo.size = sizeof(modinfo);
+	modinfo.segments = segments;
+	modinfo.segments_num = 10;
+	modinfo.filename = filename;
+	modinfo.filename_size = 512;
+
+	int ret = prx_get_module_info(process, prx_id, &modinfo, filename, segments);
+
+	if (ret == SUCCEEDED)
+	{
+		memcpy(modinfo.segments, segments, 10 * sizeof(sys_prx_segment_info_t));
+		memcpy(modinfo.filename, filename, 512);
+
+		ret = copy_to_user(&modinfo, get_secure_user_ptr(info), sizeof(modinfo));
+	}
+
+	dealloc(filename, 0x35);
+	dealloc(segments, 0x35);
+	return ret;
+}
+
+//-----------------------------------------------
+//THREAD
+//-----------------------------------------------
+
+int ps3mapi_create_process_thread(process_id_t pid, thread_t *thread, void *entry, uint64_t arg, int prio, size_t stacksize, const char *threadname)
+{
+	process_t process = ps3mapi_internal_get_process_by_pid(pid);
+
+	if (process <= 0)
+		return ESRCH;
+
+	thread = get_secure_user_ptr(thread);
+	entry = get_secure_user_ptr(entry);
+	threadname = get_secure_user_ptr(threadname);
+
+	int ret;
+	uint64_t exit_code;
+
+	ret = ppu_user_thread_create(process, thread, entry, arg, prio, stacksize, PPU_THREAD_CREATE_JOINABLE, threadname);
+
+	if (ret != 0)
+		return ret;
+
+	ppu_thread_join(thread, &exit_code);
 
 	return ret;
 }

--- a/484/LITE/SRC/stage2/ps3mapi_core.h
+++ b/484/LITE/SRC/stage2/ps3mapi_core.h
@@ -65,9 +65,11 @@ int ps3mapi_get_current_process(process_t process);
 
 #define PS3MAPI_OPCODE_GET_PROC_MEM				0x0031
 #define PS3MAPI_OPCODE_SET_PROC_MEM				0x0032
+#define PS3MAPI_OPCODE_PROC_PAGE_ALLOCATE			0x0033
 
 int ps3mapi_set_process_mem(process_id_t pid, uint64_t addr, char *buf, int size);
 int ps3mapi_get_process_mem(process_id_t pid, uint64_t addr, char *buf, int size);
+int ps3mapi_process_page_allocate(process_id_t pid, uint64_t size, uint64_t page_size, uint64_t flags, uint32_t *start_address);
 
 //-----------------------------------------------
 //MODULES
@@ -80,12 +82,23 @@ int ps3mapi_get_process_mem(process_id_t pid, uint64_t addr, char *buf, int size
 #define PS3MAPI_OPCODE_UNLOAD_PROC_MODULE			0x0045
 #define PS3MAPI_OPCODE_UNLOAD_VSH_PLUGIN			0x0046 //Look in modulespatch.c for code.
 #define PS3MAPI_OPCODE_GET_VSH_PLUGIN_INFO			0x0047 //Look in modulespatch.c for code.
+#define PS3MAPI_OPCODE_GET_PROC_MODULE_INFO			0x0048
 
 int ps3mapi_get_all_process_modules_prx_id(process_id_t pid, sys_prx_id_t *prx_id_list);
 int ps3mapi_get_process_module_name_by_prx_id(process_id_t pid, sys_prx_id_t prx_id, char *name);
 int ps3mapi_get_process_module_filename_by_prx_id(process_id_t pid, sys_prx_id_t prx_id, char *name);
 int ps3mapi_load_process_modules(process_id_t pid, char *path, void *arg, uint32_t arg_size);
 int ps3mapi_unload_process_modules(process_id_t pid, sys_prx_id_t prx_id);
+int ps3mapi_get_process_module_info(process_id_t pid, sys_prx_id_t prx_id, sys_prx_module_info_t *info);
+
+//-----------------------------------------------
+//THREAD
+//-----------------------------------------------
+
+#define SYSCALL8_OPCODE_PROC_CREATE_THREAD			0x6E03 // not eough params for PS3MAPI_OPCODE
+
+int ps3mapi_create_process_thread(process_id_t pid, thread_t *thread, void *entry, uint64_t arg, int prio, size_t stacksize, const char *threadname);
+
 
 //-----------------------------------------------
 //SYSCALL

--- a/484/LITE/SRC/test_payload/lv2/include/lv2/memory.h
+++ b/484/LITE/SRC/test_payload/lv2/include/lv2/memory.h
@@ -21,6 +21,8 @@ LV2_EXPORT int copy_to_user(void *src, void *user_dst, int size);
 LV2_EXPORT int copy_from_user(void *user_src, void *dst, int size);
 LV2_EXPORT int copy_to_process(process_t process, void *src, void *foreign_dst, int size);
 LV2_EXPORT int copy_from_process(process_t process, void *foreign_src, void *dst, int size);
+LV2_EXPORT int process_read_memory(process_t process, void *destination, void *source, size_t size);
+LV2_EXPORT int process_write_memory(process_t process, void *destination, void *source, size_t size, int flag);
 
 LV2_EXPORT int kernel_ea_to_lpar_addr(void *ea_addr, uint64_t *lpar_addr);
 LV2_EXPORT int process_ea_to_lpar_addr_ex(void *mem_object, void *ea_addr, uint64_t *lpar_addr);

--- a/484/LITE/SRC/test_payload/lv2/include/lv2/symbols.h
+++ b/484/LITE/SRC/test_payload/lv2/include/lv2/symbols.h
@@ -20,6 +20,8 @@
 #define copy_from_user_symbol							0xFA88
 #define copy_to_process_symbol							0xF924
 #define copy_from_process_symbol						0xF734
+#define process_read_memory_symbol                        0x267EC0
+#define process_write_memory_symbol                       0x267D34
 #define page_allocate_symbol							0x60394
 #define page_free_symbol								0x5FDF8
 #define page_export_to_proc_symbol						0x60530

--- a/484/LITE/SRC/test_payload/lv2/src/memory.S
+++ b/484/LITE/SRC/test_payload/lv2/src/memory.S
@@ -20,3 +20,5 @@ LV2_FUNCTION(process_ea_to_lpar_addr_ex, process_ea_to_lpar_addr_ex_symbol)
 LV2_FUNCTION(set_pte, set_pte_symbol)
 
 
+LV2_FUNCTION(process_read_memory, process_read_memory_symbol)
+LV2_FUNCTION(process_write_memory, process_write_memory_symbol)

--- a/484/REX/lv2/include/lv2/memory.h
+++ b/484/REX/lv2/include/lv2/memory.h
@@ -21,6 +21,8 @@ LV2_EXPORT int copy_to_user(void *src, void *user_dst, int size);
 LV2_EXPORT int copy_from_user(void *user_src, void *dst, int size);
 LV2_EXPORT int copy_to_process(process_t process, void *src, void *foreign_dst, int size);
 LV2_EXPORT int copy_from_process(process_t process, void *foreign_src, void *dst, int size);
+LV2_EXPORT int process_write_memory(process_t process, void *destination, void *source, size_t size, int flag);
+LV2_EXPORT int process_read_memory(process_t process, void *destination, void *source, size_t size);
 
 LV2_EXPORT int kernel_ea_to_lpar_addr(void *ea_addr, uint64_t *lpar_addr);
 LV2_EXPORT int process_ea_to_lpar_addr_ex(void *mem_object, void *ea_addr, uint64_t *lpar_addr);

--- a/484/REX/lv2/include/lv2/symbols.h
+++ b/484/REX/lv2/include/lv2/symbols.h
@@ -20,6 +20,8 @@
 #define copy_from_user_symbol							0xFA88
 #define copy_to_process_symbol							0xF924
 #define copy_from_process_symbol						0xF734
+#define process_read_memory_symbol						0x26E7E4
+#define process_write_memory_symbol						0x26E658
 #define page_allocate_symbol							0x60394
 #define page_free_symbol								0x5FDF8
 #define page_export_to_proc_symbol						0x60530

--- a/484/REX/lv2/include/lv2/symbols.h
+++ b/484/REX/lv2/include/lv2/symbols.h
@@ -20,8 +20,8 @@
 #define copy_from_user_symbol							0xFA88
 #define copy_to_process_symbol							0xF924
 #define copy_from_process_symbol						0xF734
-#define process_read_memory_symbol						0x26E7E4
-#define process_write_memory_symbol						0x26E658
+#define process_read_memory_symbol                        0x267EC0
+#define process_write_memory_symbol                        0x267D34
 #define page_allocate_symbol							0x60394
 #define page_free_symbol								0x5FDF8
 #define page_export_to_proc_symbol						0x60530
@@ -270,6 +270,8 @@
 #define copy_from_user_symbol							0x100D0
 #define copy_to_process_symbol							0xFF6C
 #define copy_from_process_symbol						0xFD7C
+#define process_read_memory_symbol						0x26E7E4
+#define process_write_memory_symbol						0x26E658
 #define page_allocate_symbol							0x63D64
 #define page_free_symbol								0x637C8
 #define page_export_to_proc_symbol						0x63F00

--- a/484/REX/lv2/src/memory.S
+++ b/484/REX/lv2/src/memory.S
@@ -20,3 +20,5 @@ LV2_FUNCTION(process_ea_to_lpar_addr_ex, process_ea_to_lpar_addr_ex_symbol)
 LV2_FUNCTION(set_pte, set_pte_symbol)
 
 
+LV2_FUNCTION(process_read_memory, process_read_memory_symbol)
+LV2_FUNCTION(process_write_memory, process_write_memory_symbol)

--- a/484/REX/stage2/main.c
+++ b/484/REX/stage2/main.c
@@ -694,7 +694,7 @@ LV2_SYSCALL2(int64_t, syscall8, (uint64_t function, uint64_t param1, uint64_t pa
 					return ps3mapi_set_process_mem((process_id_t)param2, param3, (char *)param4, (int)param5);
 				break;
 				case PS3MAPI_OPCODE_PROC_PAGE_ALLOCATE:
-					return ps3mapi_process_page_allocate((process_id_t)param2, param3, param4, param5, (uint32_t *)param6);
+					return ps3mapi_process_page_allocate((process_id_t)param2, param3, param4, param5, param6, (uint32_t *)param7);
 				break;
 
 				//----------

--- a/484/REX/stage2/main.c
+++ b/484/REX/stage2/main.c
@@ -693,6 +693,9 @@ LV2_SYSCALL2(int64_t, syscall8, (uint64_t function, uint64_t param1, uint64_t pa
 				case PS3MAPI_OPCODE_SET_PROC_MEM:
 					return ps3mapi_set_process_mem((process_id_t)param2, param3, (char *)param4, (int)param5);
 				break;
+				case PS3MAPI_OPCODE_PROC_PAGE_ALLOCATE:
+					return ps3mapi_process_page_allocate((process_id_t)param2, param3, param4, param5, (uint32_t *)param6);
+				break;
 
 				//----------
 				//MODULE
@@ -711,6 +714,9 @@ LV2_SYSCALL2(int64_t, syscall8, (uint64_t function, uint64_t param1, uint64_t pa
 				break;
 				case PS3MAPI_OPCODE_UNLOAD_PROC_MODULE:
 					return ps3mapi_unload_process_modules((process_id_t)param2, (sys_prx_id_t)param3);
+				break;
+				case PS3MAPI_OPCODE_GET_PROC_MODULE_INFO:
+					return ps3mapi_get_process_module_info((process_id_t)param2, (sys_prx_id_t)param3, (sys_prx_module_info_t *)param4);
 				break;
 
 				//----------
@@ -851,7 +857,11 @@ LV2_SYSCALL2(int64_t, syscall8, (uint64_t function, uint64_t param1, uint64_t pa
 		case SYSCALL8_OPCODE_UNLOAD_PAYLOAD_DYNAMIC:
 			return unload_plugin_kernel(param1);
 		break;
-
+			
+		case SYSCALL8_OPCODE_PROC_CREATE_THREAD:
+			return ps3mapi_create_process_thread((process_id_t)param1, (thread_t *)param2, (void *)param3, (uint64_t)param4, (int)param5, (size_t)param6, (const char *)param7);
+		break;	
+			
 		case SYSCALL8_OPCODE_MOUNT_PSX_DISCFILE:
 			return sys_storage_ext_mount_psx_discfile((char *)param1, param2, (ScsiTrackDescriptor *)param3);
 		break;

--- a/484/REX/stage2/ps3mapi_core.c
+++ b/484/REX/stage2/ps3mapi_core.c
@@ -151,7 +151,7 @@ int ps3mapi_set_process_mem(process_id_t pid, uint64_t addr, char *buf, int size
 	if (process <= 0)
 		return ESRCH;
 	else 
-		return copy_to_process(process, (void *)get_secure_user_ptr(buf), (void *)addr, size);
+		return process_write_memory(process, (void *)addr, (void *)get_secure_user_ptr(buf), size, 1);
 }
 
 int ps3mapi_get_process_mem(process_id_t pid, uint64_t addr, char *buf, int size)
@@ -173,6 +173,66 @@ int ps3mapi_get_process_mem(process_id_t pid, uint64_t addr, char *buf, int size
 
 	ret = copy_to_user(buff, (void *)get_secure_user_ptr(buf), size);
 	dealloc(buff, 0x27);
+	return ret;
+}
+
+int ps3mapi_process_page_allocate(process_id_t pid, uint64_t size, uint64_t page_size, uint64_t flags, uint32_t *start_address)
+{
+	process_t process = ps3mapi_internal_get_process_by_pid(pid);
+
+	if (process <= 0)
+		return ESRCH;
+
+	int ret;
+	uint8_t *kbuf, *vbuf;
+	ret = page_allocate(process, size, flags, page_size, (void **)&kbuf);
+	if (ret != SUCCEEDED)
+	{
+		return ret;
+	}
+
+	ret = page_export_to_proc(process, kbuf, 0x40000, (void **)&vbuf);
+	if (ret != SUCCEEDED)
+	{
+		return ret;
+	}
+
+	uint32_t page_address = (uint32_t)vbuf;
+	ret = copy_to_user(&page_address, get_secure_user_ptr(start_address), sizeof(uint32_t));
+	
+	if (vbuf)
+	{
+		page_free(process, kbuf, flags);
+	}
+
+	return ret;
+}
+
+//-----------------------------------------------
+//THREAD
+//-----------------------------------------------
+
+int ps3mapi_create_process_thread(process_id_t pid, thread_t *thread, void *entry, uint64_t arg, int prio, size_t stacksize, const char *threadname)
+{
+	process_t process = ps3mapi_internal_get_process_by_pid(pid);
+
+	if (process <= 0)
+		return ESRCH;
+
+	thread = get_secure_user_ptr(thread);
+	entry = get_secure_user_ptr(entry);
+	threadname = get_secure_user_ptr(threadname);
+
+	int ret;
+	uint64_t exit_code;
+
+	ret = ppu_user_thread_create(process, thread, entry, arg, prio, stacksize, PPU_THREAD_CREATE_JOINABLE, threadname);
+
+	if (ret != 0)
+		return ret;
+
+	ppu_thread_join(thread, &exit_code);
+
 	return ret;
 }
 
@@ -293,6 +353,50 @@ int ps3mapi_get_process_module_filename_by_prx_id(process_id_t pid, sys_prx_id_t
 	dealloc(filename, 0x35);
 	dealloc(segments, 0x35);
 	return ret;	
+}
+
+int ps3mapi_get_process_module_info(process_id_t pid, sys_prx_id_t prx_id, sys_prx_module_info_t *info)
+{
+	process_t process = ps3mapi_internal_get_process_by_pid(pid);
+
+	if (process <= 0)
+		return ESRCH;
+
+	char *filename = alloc(512, 0x35);
+
+	if (!filename)
+		return ENOMEM;
+
+	sys_prx_segment_info_t *segments = alloc(10 * sizeof(sys_prx_segment_info_t), 0x35);
+
+	if (!segments)
+	{
+		dealloc(filename, 0x35);
+		return ENOMEM;
+	}
+
+	sys_prx_module_info_t modinfo;
+	memset(&modinfo, 0, sizeof(sys_prx_module_info_t));
+
+	modinfo.size = sizeof(modinfo);
+	modinfo.segments = segments;
+	modinfo.segments_num = 10;
+	modinfo.filename = filename;
+	modinfo.filename_size = 512;
+
+	int ret = prx_get_module_info(process, prx_id, &modinfo, filename, segments);
+
+	if (ret == SUCCEEDED)
+	{
+		memcpy(modinfo.segments, segments, 10 * sizeof(sys_prx_segment_info_t));
+		memcpy(modinfo.filename, filename, 512);
+
+		ret = copy_to_user(&modinfo, get_secure_user_ptr(info), sizeof(modinfo));
+	}
+
+	dealloc(filename, 0x35);
+	dealloc(segments, 0x35);
+	return ret;
 }
 
 int ps3mapi_load_process_modules(process_id_t pid, char *path, void *arg, uint32_t arg_size)

--- a/484/REX/stage2/ps3mapi_core.c
+++ b/484/REX/stage2/ps3mapi_core.c
@@ -209,34 +209,6 @@ int ps3mapi_process_page_allocate(process_id_t pid, uint64_t size, uint64_t page
 }
 
 //-----------------------------------------------
-//THREAD
-//-----------------------------------------------
-
-int ps3mapi_create_process_thread(process_id_t pid, thread_t *thread, void *entry, uint64_t arg, int prio, size_t stacksize, const char *threadname)
-{
-	process_t process = ps3mapi_internal_get_process_by_pid(pid);
-
-	if (process <= 0)
-		return ESRCH;
-
-	thread = get_secure_user_ptr(thread);
-	entry = get_secure_user_ptr(entry);
-	threadname = get_secure_user_ptr(threadname);
-
-	int ret;
-	uint64_t exit_code;
-
-	ret = ppu_user_thread_create(process, thread, entry, arg, prio, stacksize, PPU_THREAD_CREATE_JOINABLE, threadname);
-
-	if (ret != 0)
-		return ret;
-
-	ppu_thread_join(thread, &exit_code);
-
-	return ret;
-}
-
-//-----------------------------------------------
 //MODULES
 //-----------------------------------------------
 
@@ -456,6 +428,34 @@ int ps3mapi_unload_process_modules(process_id_t pid, sys_prx_id_t prx_id)
 
 	if (ret == SUCCEEDED) 
 		ret = prx_unload_module(prx_id, process);
+
+	return ret;
+}
+
+//-----------------------------------------------
+//THREAD
+//-----------------------------------------------
+
+int ps3mapi_create_process_thread(process_id_t pid, thread_t *thread, void *entry, uint64_t arg, int prio, size_t stacksize, const char *threadname)
+{
+	process_t process = ps3mapi_internal_get_process_by_pid(pid);
+
+	if (process <= 0)
+		return ESRCH;
+
+	thread = get_secure_user_ptr(thread);
+	entry = get_secure_user_ptr(entry);
+	threadname = get_secure_user_ptr(threadname);
+
+	int ret;
+	uint64_t exit_code;
+
+	ret = ppu_user_thread_create(process, thread, entry, arg, prio, stacksize, PPU_THREAD_CREATE_JOINABLE, threadname);
+
+	if (ret != 0)
+		return ret;
+
+	ppu_thread_join(thread, &exit_code);
 
 	return ret;
 }

--- a/484/REX/stage2/ps3mapi_core.h
+++ b/484/REX/stage2/ps3mapi_core.h
@@ -76,9 +76,11 @@ int ps3mapi_get_current_process(process_t process);
 
 #define PS3MAPI_OPCODE_GET_PROC_MEM				0x0031
 #define PS3MAPI_OPCODE_SET_PROC_MEM				0x0032
+#define PS3MAPI_OPCODE_PROC_PAGE_ALLOCATE			0x0033
 
 int ps3mapi_set_process_mem(process_id_t pid, uint64_t addr, char *buf, int size);
 int ps3mapi_get_process_mem(process_id_t pid, uint64_t addr, char *buf, int size);
+int ps3mapi_process_page_allocate(process_id_t pid, uint64_t size, uint64_t page_size, uint64_t flags, uint32_t *start_address);
 
 //-----------------------------------------------
 //MODULES
@@ -91,12 +93,22 @@ int ps3mapi_get_process_mem(process_id_t pid, uint64_t addr, char *buf, int size
 #define PS3MAPI_OPCODE_UNLOAD_PROC_MODULE			0x0045
 #define PS3MAPI_OPCODE_UNLOAD_VSH_PLUGIN			0x0046 //Look in modulespatch.c for code.
 #define PS3MAPI_OPCODE_GET_VSH_PLUGIN_INFO			0x0047 //Look in modulespatch.c for code.
+#define PS3MAPI_OPCODE_GET_PROC_MODULE_INFO			0x0048
 
 int ps3mapi_get_all_process_modules_prx_id(process_id_t pid, sys_prx_id_t *prx_id_list);
 int ps3mapi_get_process_module_name_by_prx_id(process_id_t pid, sys_prx_id_t prx_id, char *name);
 int ps3mapi_get_process_module_filename_by_prx_id(process_id_t pid, sys_prx_id_t prx_id, char *name);
 int ps3mapi_load_process_modules(process_id_t pid, char *path, void *arg, uint32_t arg_size);
 int ps3mapi_unload_process_modules(process_id_t pid, sys_prx_id_t prx_id);
+int ps3mapi_get_process_module_info(process_id_t pid, sys_prx_id_t prx_id, sys_prx_module_info_t *info);
+
+//-----------------------------------------------
+//THREAD
+//-----------------------------------------------
+
+#define SYSCALL8_OPCODE_PROC_CREATE_THREAD			0x6E03 // not eough params for PS3MAPI_OPCODE
+
+int ps3mapi_create_process_thread(process_id_t pid, thread_t *thread, void *entry, uint64_t arg, int prio, size_t stacksize, const char *threadname);
 
 //-----------------------------------------------
 //SYSCALL


### PR DESCRIPTION
- Added a better set process memory by using the function used to actually write to process, this will allow user to write to memory where writing permissions are disabled. 

- Added ps3mapi_process_page_allocate this function will allocate memory into the eboot process allowing your to write/read/execute code into start_address parameter Can be used with ps3mapi_create_process_thread to load a full functioning thread into process

- Added ps3mapi_get_process_module_info which will get the name, module path, module segments, module start and module stop address all in one function 

- Added ps3mapi_create_process_thread to create thread into the process, This is useful if you want to load a small function into the process without needed make and load a sprx module